### PR TITLE
🐞 Retrieve all the record types and filter from local database

### DIFF
--- a/src/screens/SurveyList.tsx
+++ b/src/screens/SurveyList.tsx
@@ -11,7 +11,8 @@ import FilterButtonGroup from './SurveyListFilter';
 import { SurveyListRightButtons } from './SurveyListHeaderButtons';
 // services
 import { buildDictionary } from '../services/dictionary';
-import { deleteRecord, getAllRecordsWithCallback } from '../services/database/database';
+import { deleteRecord } from '../services/database/database';
+import { getAllAvailableRecordTypes } from '../services/database/metadata';
 import { forceLogout } from '../services/session';
 import { syncLocalSurvey } from '../services/sync';
 import { getLocalSurveysForList } from '../services/database/localSurvey';
@@ -65,7 +66,8 @@ export default function SurveyList({ navigation }: SurveyListProps) {
     setShowsSpinner(true);
     const prepare = async () => {
       try {
-        await getAllRecordsWithCallback(DB_TABLE.RECORD_TYPE, setRecordTypes);
+        const availableRecordTypes = await getAllAvailableRecordTypes();
+        setRecordTypes(availableRecordTypes);
         await buildDictionary();
         await refreshSurveys();
       } catch {

--- a/src/screens/SurveyList.tsx
+++ b/src/screens/SurveyList.tsx
@@ -88,11 +88,11 @@ export default function SurveyList({ navigation }: SurveyListProps) {
   useFocusEffect(
     useCallback(() => {
       const refresh = async () => {
-        setShowsSpinner(true);
         try {
+          const availableRecordTypes = await getAllAvailableRecordTypes();
+          setRecordTypes(availableRecordTypes);
           await refreshSurveys();
         } catch {}
-        setShowsSpinner(false);
       };
       refresh();
     }, [])

--- a/src/screens/SurveyTypePicker.tsx
+++ b/src/screens/SurveyTypePicker.tsx
@@ -3,7 +3,7 @@ import { View, FlatList, ImageBackground } from 'react-native';
 import { Divider } from 'react-native-elements';
 import { StackNavigationProp } from '@react-navigation/stack';
 
-import { getAllRecordsWithCallback } from '../services/database/database';
+import { getAllAvailableRecordTypes } from '../services/database/metadata';
 import { ListItem } from '../components';
 
 import LocalizationContext from '../context/localizationContext';
@@ -13,7 +13,6 @@ import {
   BACKGROUND_STYLE,
   BACKGROUND_IMAGE_STYLE,
   L10N_PREFIX,
-  DB_TABLE,
 } from '../constants';
 import { logger } from '../utility/logger';
 
@@ -33,7 +32,9 @@ export default function SurveyTypePicker({ navigation }: Props) {
 
   useEffect(() => {
     const fetch = async () => {
-      await getAllRecordsWithCallback(DB_TABLE.RECORD_TYPE, setRecordTypes);
+      // Only active record types should be queried
+      const result = await getAllAvailableRecordTypes();
+      setRecordTypes(result);
     };
     fetch();
   }, []);

--- a/src/services/database/metadata.ts
+++ b/src/services/database/metadata.ts
@@ -1,7 +1,6 @@
 import { getAllRecords, getRecords } from './database';
 import { SQLiteRecordType, SQLitePicklistValue } from '../../types/sqlite';
 import { DB_TABLE } from '../../constants';
-import { logger } from '../../utility/logger';
 
 /**
  * @description Get all the available record types of the survey object from local database.
@@ -10,9 +9,7 @@ import { logger } from '../../utility/logger';
  */
 export const getAllAvailableRecordTypes = async (): Promise<Array<SQLiteRecordType>> => {
   const recordTypes: Array<SQLiteRecordType> = await getAllRecords(DB_TABLE.RECORD_TYPE);
-  const result = recordTypes.filter(r => r.active).filter((r, i, array) => (array.length > 1 ? !r.master : true));
-  logger('DEBUG', 'getAllAvailableRecordTypes', result);
-  return result;
+  return recordTypes.filter(r => r.active).filter((r, i, array) => (array.length > 1 ? !r.master : true));
 };
 
 /**

--- a/src/services/database/metadata.ts
+++ b/src/services/database/metadata.ts
@@ -1,13 +1,18 @@
 import { getAllRecords, getRecords } from './database';
 import { SQLiteRecordType, SQLitePicklistValue } from '../../types/sqlite';
 import { DB_TABLE } from '../../constants';
+import { logger } from '../../utility/logger';
 
 /**
- * @description Get all the record types of the survey object from local database
+ * @description Get all the available record types of the survey object from local database.
+ * If there's active record types other than master, they will be returned. Master record type will not be returned.
+ * If master is only the active record type, it will be returned.
  */
-export const getAllRecordTypes = async (): Promise<Array<SQLiteRecordType>> => {
+export const getAllAvailableRecordTypes = async (): Promise<Array<SQLiteRecordType>> => {
   const recordTypes: Array<SQLiteRecordType> = await getAllRecords(DB_TABLE.RECORD_TYPE);
-  return recordTypes;
+  const result = recordTypes.filter(r => r.active).filter((r, i, array) => (array.length > 1 ? !r.master : true));
+  logger('DEBUG', 'getAllAvailableRecordTypes', result);
+  return result;
 };
 
 /**

--- a/src/services/dictionary.ts
+++ b/src/services/dictionary.ts
@@ -1,6 +1,5 @@
 import { getAllRecords } from './database/database';
 import { prepareLocalizationTable } from './database/localization';
-import { getAllRecordTypes } from './database/metadata';
 
 import { logger } from '../utility/logger';
 import { DB_TABLE, L10N_PREFIX } from '../constants';
@@ -12,7 +11,7 @@ import i18n from '../config/i18n';
  */
 export const buildDictionary = async () => {
   // original labels
-  const recordTypes = await getAllRecordTypes();
+  const recordTypes = await getAllRecords(DB_TABLE.RECORD_TYPE);
   const recordTypeLabels = recordTypes.reduce((result, current) => {
     result[`${L10N_PREFIX.RecordType}${current.developerName}`] = current.label;
     return result;

--- a/src/services/salesforce/metadata.ts
+++ b/src/services/salesforce/metadata.ts
@@ -34,15 +34,14 @@ export const storeRecordTypesWithCompactLayout = async () => {
   ) {
     return Promise.reject({ error: 'invalid_record_type' });
   }
-  const recordTypes: Array<SQLiteRawRecordType> = response.recordTypeMappings
-    .filter(r => r.active)
-    .filter((r, i, array) => (array.length > 1 ? r.master === false : true))
-    .map(r => ({
-      developerName: r.developerName,
-      label: r.name,
-      recordTypeId: r.recordTypeId,
-      layoutId: r.layoutId,
-    }));
+  const recordTypes: Array<SQLiteRawRecordType> = response.recordTypeMappings.map(r => ({
+    developerName: r.developerName,
+    label: r.name,
+    recordTypeId: r.recordTypeId,
+    layoutId: r.layoutId,
+    active: r.active,
+    master: r.master,
+  }));
   const compositeCompactLayoutResponse: CompositeCompactLayoutResponse = await describeCompactLayouts(
     SURVEY_OBJECT,
     recordTypes.map(r => r.recordTypeId)

--- a/src/services/salesforce/survey.ts
+++ b/src/services/salesforce/survey.ts
@@ -73,11 +73,11 @@ export const storeOnlineSurveys = async () => {
     return;
   }
   const localSurveys = surveys.map(s => ({ ...s, _syncStatus: SYNC_STATUS_SYNCED }));
-  saveRecords(
+  const masterRecordTypeId = recordTypes.find(r => r.master).recordTypeId;
+  await saveRecords(
     DB_TABLE.SURVEY,
-    hasMasterRecordTypeOnly(recordTypes)
-      ? localSurveys.map(s => ({ ...s, [RECORD_TYPE_ID_FIELD]: recordTypes[0].recordTypeId }))
-      : localSurveys,
+    // Set master record type id if the record type id field is null.
+    localSurveys.map(s => (s[RECORD_TYPE_ID_FIELD] ? s : { ...s, [RECORD_TYPE_ID_FIELD]: masterRecordTypeId })),
     undefined
   );
 };
@@ -153,5 +153,6 @@ export const fetchSurveysWithTitleFields = async (surveyIds: Array<string>): Pro
  * @private
  */
 const hasMasterRecordTypeOnly = (recordTypes: Array<SQLiteRecordType>): boolean => {
-  return recordTypes.length === 1 && recordTypes[0].developerName === 'Master';
+  const activeRecordTypes = recordTypes.filter(r => r.active);
+  return activeRecordTypes.length === 1 && activeRecordTypes[0].master;
 };

--- a/src/services/sync.ts
+++ b/src/services/sync.ts
@@ -35,6 +35,8 @@ export const syncLocalSurveys = async (localSurveys: Array<any>) => {
       await updateSurveyStatusSynced(refreshedSurveys);
       notifySuccess(`${response.results.length === 1 ? 'Survey is' : 'Surveys are'} successfully uploaded!`);
       return;
+    } else if (response.hasErrors) {
+      throw new Error(`Upload failed: ${response.results[0].errors[0].message}`);
     } else {
       throw new Error('Unexpected error occued while uploading. Contact your adminsitrator.');
     }

--- a/src/types/sqlite.ts
+++ b/src/types/sqlite.ts
@@ -3,6 +3,8 @@ export const SQLiteRawRecordTypeObject = {
   label: 'string',
   recordTypeId: 'string',
   layoutId: 'string',
+  active: true,
+  master: true,
 };
 
 export const SQLiteSurveyTitleObject = {

--- a/tests/services/database.metadata.test.js
+++ b/tests/services/database.metadata.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { getRecords, getAllRecords } from '../../src/services/database/database';
-import { getAllRecordTypes, getPicklistValues } from '../../src/services/database/metadata';
+import { getAllAvailableRecordTypes, getPicklistValues } from '../../src/services/database/metadata';
 
 jest.mock('expo-sqlite', () => ({ default: {} }));
 jest.mock('../../src/services/database/database', () => ({
@@ -8,7 +8,7 @@ jest.mock('../../src/services/database/database', () => ({
   getRecords: jest.fn(),
 }));
 
-describe('getAllRecordTypes', () => {
+describe('getAllAvailableRecordTypes', () => {
   it('recordtypes', async () => {
     getAllRecords.mockImplementation(() =>
       Promise.resolve([
@@ -17,17 +17,29 @@ describe('getAllRecordTypes', () => {
           developerName: 'Test_1',
           label: 'Test 1',
           layoutId: '00h5h000000mTxOAAU',
+          active: true,
+          master: false,
         },
         {
           recordTypeId: '0125h000000kNJMAA2',
           developerName: 'Test_2',
           label: 'Test 2',
           layoutId: '00h5h000000mTxOAAU',
+          active: true,
+          master: false,
+        },
+        {
+          recordTypeId: '0125h0000000000AAA',
+          developerName: 'Master',
+          label: 'Master',
+          layoutId: '00h5h000000mTxOAAU',
+          active: true,
+          master: true,
         },
       ])
     );
 
-    const recordTypes = await getAllRecordTypes();
+    const recordTypes = await getAllAvailableRecordTypes();
     expect(recordTypes.length).toBe(2);
   });
 });


### PR DESCRIPTION
We used to filter the response of describeLayout to get the active record types, but it prevents from seeing the survey of the record types enabled before and disabled now. I fixed this design to get all the record types and filter them in each screen.